### PR TITLE
Update Semantic Scholar suggestion generation and popup

### DIFF
--- a/arxivdigest/core/config.py
+++ b/arxivdigest/core/config.py
@@ -49,6 +49,8 @@ config_arxiv_scraper = config.get('arxiv_scraper_config')
 jwtKey = config_frontend.get('jwt_key')
 secret_key = config_frontend.get('secret_key')
 
+enable_semantic_scholar_suggestion_popup = config.get('enable_semantic_scholar_suggestion_popup', False)
+
 
 class Constants:
     """This class contains constants that are not configurable."""

--- a/arxivdigest/core/database/users_db.py
+++ b/arxivdigest/core/database/users_db.py
@@ -58,7 +58,14 @@ def get_users_for_suggestion_generation(limit, offset):
                  ORDER BY user_id
                  LIMIT %s OFFSET %s'''
         cur.execute(sql, (limit, offset))
-        return {u.pop('user_id'): u for u in cur.fetchall()}
+        users = {u.pop('user_id'): u for u in cur.fetchall()}
+        for user_id, user_data in users.items():
+            sql = '''SELECT t.topic FROM user_topics ut 
+                     NATURAL JOIN topics t WHERE user_id = %s AND NOT t.filtered
+                     and ut.state in ('USER_ADDED','SYSTEM_RECOMMENDED_ACCEPTED')'''
+            cur.execute(sql, (user_id,))
+            user_data['topics'] = cur.fetchall()
+        return users
 
 
 def assign_unsubscribe_trace(user_id):

--- a/arxivdigest/frontend/app.py
+++ b/arxivdigest/frontend/app.py
@@ -19,6 +19,7 @@ import arxivdigest
 from arxivdigest.core.config import config_frontend
 from arxivdigest.core.config import jwtKey
 from arxivdigest.core.config import secret_key
+from arxivdigest.core.config import enable_semantic_scholar_suggestion_popup
 from arxivdigest.frontend.database import general as db
 from arxivdigest.frontend.views import admin
 from arxivdigest.frontend.views import articles
@@ -127,7 +128,7 @@ def teardownDb(exception):
 @app.context_processor
 def inject_semantic_scholar_suggestions():
     """Inject the Semantic Scholar suggestions of the current user into the context of the current template."""
-    if g.loggedIn:
+    if g.loggedIn and enable_semantic_scholar_suggestion_popup:
         user = db.get_user(g.user)
         if user['show_semantic_scholar_popup'] and len(user['semantic_scholar_suggestions']) > 0:
             return {'semantic_scholar_suggestions': user['semantic_scholar_suggestions']}

--- a/config.json
+++ b/config.json
@@ -53,5 +53,6 @@
         "last_n_days": 1,
         "start_date": null,
         "end_date": null
-    }
+    },
+    "enable_semantic_scholar_suggestion_popup": false
 }

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -29,14 +29,18 @@ This directory contains three types of scripts:
 currently do not provide a link to their Semantic Scholar profiles:
 
 ```
-usage: gen_semantic_scholar_suggestions.py [-h] [--index INDEX] [--hosts HOSTS]
+usage: gen_semantic_scholar_suggestions.py [-h] [--index INDEX] [--hosts HOSTS] [--method {score,frequency}] [--batch-size BATCH_SIZE]
 
 Generate Semantic Scholar profile suggestions for all arXivDigest users whose profiles currently do not contain a link to a profile.
 
 optional arguments:
-  -h, --help     show this help message and exit
-  --index INDEX  Semantic Scholar Open Research Corpus Elasticsearch index name (default: open_research)
-  --hosts HOSTS  Elasticsearch hosts (default: ['http://127.0.0.1:9200'])
+  -h, --help            show this help message and exit
+  --index INDEX         Semantic Scholar Open Research Corpus Elasticsearch index name (default: open_research)
+  --hosts HOSTS         Elasticsearch hosts (default: ['http://127.0.0.1:9200'])
+  --method {score,frequency}
+                        profile matching method (default: score)
+  --batch-size BATCH_SIZE
+                        user batch size (suggestions are generated in batches of users) (default: 500)
 ```
 
 The generated suggestions will be shown to the users in a modal upon login.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -43,7 +43,7 @@ optional arguments:
                         user batch size (suggestions are generated in batches of users) (default: 500)
   --max-suggestions MAX_SUGGESTIONS
                         max number of suggestions per user (default: 5)
-  -k K                  number of top Elasticsearch query results (k-top) to take into consideration when finding profile candidates for a user (default: 50)
+  -k K                  number of top Elasticsearch query results (top-k) to take into consideration when finding profile candidates for a user (default: 50)
 ```
 
 The generated suggestions will be shown to the users in a modal upon login.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -29,7 +29,7 @@ This directory contains three types of scripts:
 currently do not provide a link to their Semantic Scholar profiles:
 
 ```
-usage: gen_semantic_scholar_suggestions.py [-h] [--index INDEX] [--hosts HOSTS] [--method {score,frequency}] [--batch-size BATCH_SIZE]
+usage: gen_semantic_scholar_suggestions.py [-h] [--index INDEX] [--hosts HOSTS] [--method {score,frequency}] [--batch-size BATCH_SIZE] [--max-suggestions MAX_SUGGESTIONS] [-k K]
 
 Generate Semantic Scholar profile suggestions for all arXivDigest users whose profiles currently do not contain a link to a profile.
 
@@ -41,6 +41,9 @@ optional arguments:
                         profile matching method (default: score)
   --batch-size BATCH_SIZE
                         user batch size (suggestions are generated in batches of users) (default: 500)
+  --max-suggestions MAX_SUGGESTIONS
+                        max number of suggestions per user (default: 5)
+  -k K                  number of top Elasticsearch query results (k-top) to take into consideration when finding profile candidates for a user (default: 50)
 ```
 
 The generated suggestions will be shown to the users in a modal upon login.

--- a/scripts/gen_semantic_scholar_suggestions.py
+++ b/scripts/gen_semantic_scholar_suggestions.py
@@ -1,75 +1,161 @@
 from elasticsearch import Elasticsearch
-from collections import Counter
 from datetime import datetime
+from collections import defaultdict
 import argparse
 
 from arxivdigest.core.database import users_db, semantic_scholar_suggestions_db as s2_db
 
 
-def author_id_lookup(es: Elasticsearch, name: str, index: str, k=50, max_results=5):
+def find_author_candidates_by_frequency(
+    es: Elasticsearch, index: str, user: dict, k=50, max_results=5
+) -> dict:
     """
-    Find candidate Semantic Scholar author IDs for an author based on their name.
+    Find candidate Semantic Scholar author IDs for a user. Candidates are found by:
+        1. Querying the S2ORC Elasticsearch index for the user's name.
+        2. Ranking the authors present in the query results based on their frequency of occurrence.
 
-    The IDs are found by: (1) searching for the author in the Semantic Scholar Open Research Corpus, (2) ranking the
-    author IDs based on their frequency of occurrence among the top-k results.
     :param es: Elasticsearch instance.
-    :param name: Author name.
-    :param index: Elasticsearch index.
-    :param k: Number of top papers to consider when searching.
-    :param max_results: Max number of candidate IDs returned.
-    :return: List of tuples (author ID, name) sorted by frequency of occurrence in the search results.
+    :param user: User.
+    :param index: S2ORC Elasticsearch index name.
+    :param k: Number of top Elasticsearch query results to take into consideration.
+    :param max_results: Max number of candidates returned.
+    :return: Dictionary {author_id: {name, score}).
     """
     query = {
-        "query": {
-            "match": {
-                "authors.name": {
-                    "query": name,
-                    "operator": "and",
-
-                }
-            }
-        },
-        "_source": "authors"
+        "query": {"match": {"authors.name": f"{user['firstname']} {user['lastname']}"}}
     }
     results = es.search(index=index, body=query, size=k)["hits"]["hits"]
-    authors = []
+    authors = defaultdict(lambda: {"name": "", "count": 0})
     for article in results:
         for author in article["_source"]["authors"]:
             for author_id in author["ids"]:
-                authors.append((author_id, author["name"]))
-    id_counts = Counter(author_id for author_id, name in authors)
+                authors[author_id]["name"] = author["name"]
+                authors[author_id]["count"] += 1
 
     return {
-        author_id: {
-            "name": name,
-            "score": id_counts[author_id]
-        }
-        for author_id, name in authors[:max_results] if id_counts[author_id] > 1
+        author_id: author_data
+        for author_id, author_data in sorted(
+            authors.items(), key=lambda a: a[1]["count"], reverse=True
+        )[:max_results]
     }
 
 
-def gen_suggestions(es: Elasticsearch, index: str):
+def find_author_candidates_by_score(
+    es: Elasticsearch, index: str, user: dict, k=50, max_results=5
+) -> dict:
+    """
+    Find candidate Semantic Scholar author IDs for a user. Candidates are found by:
+        1. Querying the S2ORC Elasticsearch index for the user's name, along with the user's topics of interest.
+        2. Ranking the authors present in the query results based on the sum of the scores of the documents they have
+        authored.
+
+    :param es: Elasticsearch instance.
+    :param user: User.
+    :param index: S2ORC Elasticsearch index name.
+    :param k: Number of top Elasticsearch query results to take into consideration.
+    :param max_results: Max number of candidates returned.
+    :return: Dictionary {author_id: {name, score}).
+    """
+    query = {
+        "query": {
+            "bool": {
+                "must": {
+                    "match": {"authors.name": f"{user['firstname']} {user['lastname']}"}
+                },
+                "should": [
+                    {
+                        "multi_match": {
+                            "query": topic["topic"],
+                            "fields": ["title", "paperAbstract", "fieldsOfStudy"],
+                        }
+                    }
+                    for topic in user["topics"]
+                ],
+            },
+        }
+    }
+    results = es.search(index=index, body=query, size=k)["hits"]["hits"]
+    authors = defaultdict(lambda: {"name": "", "score": 0})
+    for article in results:
+        for author in article["_source"]["authors"]:
+            for author_id in author["ids"]:
+                authors[author_id]["name"] = author["name"]
+                authors[author_id]["score"] += article["_score"]
+
+    return {
+        author_id: author_data
+        for author_id, author_data in sorted(
+            authors.items(), key=lambda a: a[1]["score"], reverse=True
+        )[:max_results]
+    }
+
+
+def gen_suggestions(
+    es: Elasticsearch, index: str, matching_method: str, batch_size: int
+):
+    """
+    Generate suggestions for users in batches.
+
+    :param es: Elasticsearch instance.
+    :param index: S2ORC Elasticsearch index name.
+    :param matching_method: Profile matching method ("score" or "frequency").
+    :param batch_size: User batch size.
+    """
     timestamp = datetime.now()
     number_of_users = users_db.get_number_of_users_for_suggestion_generation()
-    print(f"Generating suggestions for {number_of_users} user(s) (timestamp: {timestamp}).")
+    print(
+        f"Generating suggestions for {number_of_users} user(s) (timestamp: {timestamp})."
+    )
 
     offset = 0
     while offset < number_of_users:
-        users = users_db.get_users_for_suggestion_generation(100, offset)
-        suggestions = {user_id: author_id_lookup(es, f"{user_data['firstname']} {user_data['lastname']}", index)
-                       for user_id, user_data in users.items()}
+        users = users_db.get_users_for_suggestion_generation(batch_size, offset)
+        suggestions = {
+            user_id: PROFILE_MATCHING_METHODS[matching_method](es, index, user_data)
+            for user_id, user_data in users.items()
+        }
         s2_db.update_semantic_scholar_suggestions(suggestions, timestamp)
-        offset += 100
+        offset += batch_size
 
 
-if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description="Generate Semantic Scholar profile suggestions for all arXivDigest "
-                                                 "users whose profiles currently do not contain a link to a "
-                                                 "profile.", formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    parser.add_argument("--index", type=str, help="Semantic Scholar Open Research Corpus Elasticsearch index name",
-                        default="open_research")
-    parser.add_argument("--hosts", type=list, help="Elasticsearch hosts", default=["http://127.0.0.1:9200"])
+PROFILE_MATCHING_METHODS = {
+    "score": find_author_candidates_by_score,
+    "frequency": find_author_candidates_by_frequency,
+}
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Generate Semantic Scholar profile suggestions for all arXivDigest "
+        "users whose profiles currently do not contain a link to a "
+        "profile.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--index",
+        type=str,
+        help="Semantic Scholar Open Research Corpus Elasticsearch index name",
+        default="open_research",
+    )
+    parser.add_argument(
+        "--hosts",
+        type=list,
+        help="Elasticsearch hosts",
+        default=["http://127.0.0.1:9200"],
+    )
+    parser.add_argument(
+        "--method",
+        help="profile matching method",
+        default="score",
+        choices=PROFILE_MATCHING_METHODS.keys(),
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        help="user batch size (suggestions are generated in batches of users)",
+        default=500,
+    )
     args = parser.parse_args()
 
     es = Elasticsearch(hosts=args.hosts)
-    gen_suggestions(es, index=args.index)
+    gen_suggestions(es, args.index, args.method, args.batch_size)

--- a/scripts/gen_semantic_scholar_suggestions.py
+++ b/scripts/gen_semantic_scholar_suggestions.py
@@ -105,7 +105,7 @@ def gen_suggestions(
     :param index: S2ORC Elasticsearch index name.
     :param matching_method: Profile matching method ("score" or "frequency").
     :param max_suggestions: Max number of suggestions generated per user.
-    :param k: Number of top Elasticsearch query results (k-top) to take into consideration when finding profile
+    :param k: Number of top Elasticsearch query results (top-k) to take into consideration when finding profile
     candidates for a user.
     :param batch_size: User batch size.
     """
@@ -174,7 +174,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "-k",
         type=int,
-        help="number of top Elasticsearch query results (k-top) to take into consideration when finding profile "
+        help="number of top Elasticsearch query results (top-k) to take into consideration when finding profile "
         "candidates for a user",
         default=50,
     )

--- a/scripts/gen_semantic_scholar_suggestions.py
+++ b/scripts/gen_semantic_scholar_suggestions.py
@@ -29,7 +29,7 @@ def find_author_candidates_by_frequency(
     for article in results:
         for author in article["_source"]["authors"]:
             for author_id in author["ids"]:
-                authors[author_id]["name"] = author["name"]
+                authors[author_id]["name"] = " ".join(author["name"].split())
                 authors[author_id]["count"] += 1
 
     return {
@@ -79,7 +79,7 @@ def find_author_candidates_by_score(
     for article in results:
         for author in article["_source"]["authors"]:
             for author_id in author["ids"]:
-                authors[author_id]["name"] = author["name"]
+                authors[author_id]["name"] = " ".join(author["name"].split())
                 authors[author_id]["score"] += article["_score"]
 
     return {


### PR DESCRIPTION
Add flag to `config.json` to enable or disable the Semantic Scholar profile suggestion popup globally, and update the suggestion generation script:
- Clean up existing code.
- Implement score-based profile matching method.
- Add more options.