### PR TITLE
Tweak Semantic Scholar suggestion generation

### DIFF
--- a/arxivdigest/core/database/users_db.py
+++ b/arxivdigest/core/database/users_db.py
@@ -58,7 +58,7 @@ def get_users_for_suggestion_generation(limit, offset):
                  ORDER BY user_id
                  LIMIT %s OFFSET %s'''
         cur.execute(sql, (limit, offset))
-        users = {u.pop('user_id'): u for u in cur.fetchall()}
+        users = {u['user_id']: u for u in cur.fetchall()}
         for user_id, user_data in users.items():
             sql = '''SELECT t.topic FROM user_topics ut 
                      NATURAL JOIN topics t WHERE user_id = %s AND NOT t.filtered


### PR DESCRIPTION
- Issue one seperate Elasticsearch query per topic of interest.
- Print progress.
- Fix: replace "count" key with "score" key in frequency-based method.